### PR TITLE
ci: prune no longer required

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           command: docker-builder
           dry-run: ${{github.ref != 'refs/heads/main'}}
-          prune: true
+          prune: false


### PR DESCRIPTION
As we reuse the huge base layers, we should no longer prune, so we do not need to export them again and again from builder to docker host