### PR TITLE
fix(deps): downgrade to working CacheControl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ RUN install-pip pipenv 2020.11.15
 
 # renovate: datasource=github-releases lookupName=python-poetry/poetry
 RUN install-tool poetry 1.1.11
+# Workaround until https://github.com/python-poetry/poetry/issues/4688 is fixed
+RUN /usr/local/poetry/*/venv/bin/pip install cachecontrol==0.12.6
 
 # renovate: datasource=pypi
 RUN install-pip hashin 0.15.0


### PR DESCRIPTION
As a temporary measure to work around https://github.com/python-poetry/poetry/issues/4688, downgrade CacheControl in the poetry virtualenv to a working version.

This fixes #366