### PR TITLE
fix: use golang datasource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN install-tool php 7.4.30
 # renovate: datasource=github-releases lookupName=composer/composer
 RUN install-tool composer 2.3.10
 
-# renovate: datasource=docker versioning=docker
+# renovate: datasource=golang-version
 RUN install-tool golang 1.18.5
 
 # renovate: datasource=github-releases lookupName=containerbase/python-prebuild


### PR DESCRIPTION
Now that Renovate supports updating the Go version in `go.mod` and uses the `go-version` datasource, it make sense to use the datasource here as well. Since the Docker datasource lags behind, when a minor is released, Renovate fails to run `go` commands and update the `go.sum` file. I know it might not help much with Mend Renovate, but it should reduce the time the update is in a broken state for the self-hosted version.

https://github.com/renovatebot/renovate/blob/32.141.0/lib/modules/manager/gomod/extract.ts#L38-L50

Other solutions to sync things up could be to change the manager to use the Docker datasource, a lot of users build their projects with the Docker image which could one more reason for this choice.

Also, using `binarySource` to install the right version would solve the issue completely.