### PR TITLE
fix: Add flux cli to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,9 @@ RUN install-tool helm v3.9.4
 # renovate: datasource=github-releases lookupName=jsonnet-bundler/jsonnet-bundler
 RUN install-tool jb v0.5.1
 
+# renovate: datasource=github-releases lookupName=fluxcd/flux2
+RUN install-tool flux v0.34.0
+
 COPY --from=tsbuild /usr/src/app/package.json package.json
 COPY --from=tsbuild /usr/src/app/dist dist
 COPY --from=tsbuild /usr/src/app/node_modules node_modules


### PR DESCRIPTION
Currently the full docker image is missing the flux cli causing failed updates, like so:

> The artifact failure details are included below:
> File name: flux-system/gotk-components.yaml
>
> Command failed: flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > flux-system/gotk-components.yaml 
> /bin/sh: 1: flux: not found