### PR TITLE
feat: prepare all tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ LABEL org.opencontainers.image.source="https://github.com/renovatebot/renovate" 
   org.opencontainers.image.url="https://renovatebot.com" \
   org.opencontainers.image.licenses="AGPL-3.0-only"
 
+# prepare all tools
+RUN prepare-tool all
+
 # renovate: datasource=node
 RUN install-tool node v16.19.0
 


### PR DESCRIPTION
So even future tools which needs prepare and are not installed will work with `binarySource=install`