### PR TITLE
ci: trivy scanning action

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,27 @@
+name: trivy
+
+on:
+  schedule:
+    - cron: '59 11 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # v0.10.0
+        with:
+          image-ref: 'ghcr.io/renovatebot/renovate:latest'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      - uses: github/codeql-action/upload-sarif@29b1f65c5e92e24fe6b6647da1eaabe529cec70f # v2.3.3
+        with:
+          sarif_file: trivy-results.sarif


### PR DESCRIPTION
This GitHub workflow will run a [Trivy][1] scan `ghcr.io/renovatebot/renovate:latest` daily at 11:59 AM and upload the SARIF file to [GitHub code scanning][2].

[1]: https://github.com/aquasecurity/trivy
[2]: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github