### PR TITLE
fix: drop unused lerna

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,9 +81,6 @@ RUN install-tool dotnet 7.0.404
 # renovate: datasource=npm versioning=npm
 RUN install-tool pnpm 8.10.5
 
-# renovate: datasource=npm versioning=npm
-RUN install-tool lerna 7.4.2
-
 # renovate: datasource=github-releases lookupName=helm/helm
 RUN install-tool helm v3.13.2
 


### PR DESCRIPTION
Renovate no longer uses lerna.

Could technically break some users when they use lerna in `postUpdateCommands`